### PR TITLE
Don't allow packets to egress the in_port on flow match.

### DIFF
--- a/ZodiacFX/src/command.c
+++ b/ZodiacFX/src/command.c
@@ -929,9 +929,10 @@ void command_openflow(char *command, char *param1, char *param2, char *param3)
 							struct ofp_action_output * action_out = act_hdr;
 							printf("  Action %d:\r\n",q+1);
 							if (ntohs(action_out->port) <= 255) printf("   Output: %d\r\n", ntohs(action_out->port));
-							if (ntohs(action_out->port) == OFPP_CONTROLLER) printf("   Output: CONTROLLER\r\n");
-							if (ntohs(action_out->port) == OFPP_ALL) printf("   Output: ALL\r\n");
+							if (ntohs(action_out->port) == OFPP_IN_PORT) printf("   Output: IN_PORT\r\n");
 							if (ntohs(action_out->port) == OFPP_FLOOD) printf("   Output: FLOOD\r\n");
+							if (ntohs(action_out->port) == OFPP_ALL) printf("   Output: ALL\r\n");
+							if (ntohs(action_out->port) == OFPP_CONTROLLER) printf("   Output: CONTROLLER\r\n");
 						}
 						if(act_hdr->len != 0 && ntohs(act_hdr->type) == OFPAT10_SET_VLAN_VID) //
 						{
@@ -1114,12 +1115,18 @@ void command_openflow(char *command, char *param1, char *param2, char *param3)
 									if (htonl(act_output->port) < OFPP13_MAX)
 									{
 										printf("   Output Port: %d\r\n", htonl(act_output->port));
-									} else if (htonl(act_output->port) == OFPP13_CONTROLLER)
+									} else if (htonl(act_output->port) == OFPP13_IN_PORT)
 									{
-										printf("   Output: CONTROLLER \r\n");
+										printf("   Output: IN_PORT \r\n");
 									} else if (htonl(act_output->port) == OFPP13_FLOOD)
 									{
 										printf("   Output: FLOOD \r\n");
+									} else if (htonl(act_output->port) == OFPP13_ALL)
+									{
+										printf("   Output: ALL \r\n");
+									} else if (htonl(act_output->port) == OFPP13_CONTROLLER)
+									{
+										printf("   Output: CONTROLLER \r\n");
 									}
 									act_output = NULL;
 								}

--- a/ZodiacFX/src/openflow_10.c
+++ b/ZodiacFX/src/openflow_10.c
@@ -169,9 +169,15 @@ void nnOF10_tablelookup(uint8_t *p_uc_data, uint32_t *ul_size, int port)
 					{
 						case OFPAT10_OUTPUT:
 						action_out = act_hdr;
-						if (ntohs(action_out->port) <= 255) // physical port
+						if (ntohs(action_out->port) <= 255 && ntohs(action_out->port) != port) // physical port
 						{
 							outport = (1<< (ntohs(action_out->port)-1));
+							gmac_write(p_uc_data, packet_size, outport);
+						}
+
+						if (ntohs(action_out->port) == OFPP_IN_PORT)
+						{
+							outport = (1<< (port-1));
 							gmac_write(p_uc_data, packet_size, outport);
 						}
 

--- a/ZodiacFX/src/openflow_13.c
+++ b/ZodiacFX/src/openflow_13.c
@@ -165,10 +165,15 @@ void nnOF13_tablelookup(uint8_t *p_uc_data, uint32_t *ul_size, int port)
 						if (htons(act_hdr->type) == OFPAT13_OUTPUT)
 						{
 							struct ofp13_action_output *act_output = act_hdr;
-							if (htonl(act_output->port) < OFPP13_MAX)
+							if (htonl(act_output->port) < OFPP13_MAX && htonl(act_output->port) != port)
 							{
 								int outport = (1<< (ntohl(act_output->port)-1));
 								TRACE("Output to port %d (%d bytes)", ntohl(act_output->port), packet_size);
+								gmac_write(p_uc_data, packet_size, outport);
+							} else if (htonl(act_output->port) == OFPP13_IN_PORT)
+							{
+								int outport = (1<< (port-1));
+								if (trace == true)printf("Output to in_port %d (%d bytes)\r\n", port, packet_size);
 								gmac_write(p_uc_data, packet_size, outport);
 							} else if (htonl(act_output->port) == OFPP13_CONTROLLER)
 							{


### PR DESCRIPTION
In OpenFlow spec when a packet hits a flow match that flow match should not send the packet back out of the ingress port unless the OFPP_IN_PORT reserved port is used as an output action.

This PR fixes this incompatibility and also adds the ability for the CLI to print when OFPP_IN_PORT is used as an output action.

This PR also fixes broadcast loops that occur when multiple ZodiacFX boards are connected together and controlled by the Faucet switch controller.