### PR TITLE
OFPMP_TABLE response should return all supported tables

### DIFF
--- a/ZodiacFX/src/openflow.c
+++ b/ZodiacFX/src/openflow.c
@@ -57,7 +57,7 @@ struct flows_counter flow_counters[MAX_FLOWS];
 struct flow_tbl_actions flow_actions[MAX_FLOWS];
 struct table_counter table_counters[MAX_TABLES];
 int iLastFlow = 0;
-uint8_t shared_buffer[2048];
+uint8_t shared_buffer[SHARED_BUFFER_LEN];
 char sysbuf[64];
 struct ip_addr serverIP;
 int OF_Version = 0x00;

--- a/ZodiacFX/src/openflow.h
+++ b/ZodiacFX/src/openflow.h
@@ -85,4 +85,6 @@ void flowrem_notif(int flowid, uint8_t reason);
 (((x) & 0xff000000UL) >> 24))
 #define NTOHL(x) HTONL(x)
 
+#define SHARED_BUFFER_LEN 2048
+
 #endif /* OPENFLOW_H_ */

--- a/ZodiacFX/src/openflow_13.c
+++ b/ZodiacFX/src/openflow_13.c
@@ -667,31 +667,26 @@ int multi_portdesc_reply13(uint8_t *buffer, struct ofp13_multipart_request *msg)
 */
 int multi_table_reply13(uint8_t *buffer, struct ofp13_multipart_request *msg)
 {
-	int len = offsetof(struct ofp13_multipart_reply, body) + sizeof(struct ofp13_table_stats);
+	int len = offsetof(struct ofp13_multipart_reply, body) + sizeof(struct ofp13_table_stats) * MAX_TABLES;
+	if (SHARED_BUFFER_LEN - multi_pos < len){
+		return 0; // guard for buffer overrun
+	}
+	bzero(buffer, len);
 	struct ofp13_multipart_reply *reply = buffer;
 	reply->header.version = OF_Version;
 	reply->header.type = OFPT13_MULTIPART_REPLY;
+	reply->header.length = htons(len);
 	reply->header.xid = msg->header.xid;
 	reply->type = htons(OFPMP13_TABLE);
 	reply->flags = 0;
 	
 	struct ofp13_table_stats *stats = reply->body;
-	for(uint8_t table_id=0; table_id<=OFPTT_MAX; table_id++){
+	for(uint8_t table_id=0; table_id<MAX_TABLES; table_id++){
 		uint32_t active = 0;
 		for(int i=0; i<iLastFlow; i++) {
 			if (flow_counters[i].active == true && flow_match13[i].table_id==table_id){
 				active++;
 			}
-		}
-		if(active == 0){
-			continue;
-		}
-		int len2 = len + sizeof(struct ofp13_table_stats);
-		if(len2 > 2048 - multi_pos){
-			// TODO: shall we support OFPMPF_REPLY_MORE ?
-			break;
-		} else {
-			len = len2;
 		}
 		stats->table_id = table_id;
 		stats->active_count = htonl(active);
@@ -699,7 +694,6 @@ int multi_table_reply13(uint8_t *buffer, struct ofp13_multipart_request *msg)
 		stats->lookup_count = htonll(table_counters[table_id].lookup_count);
 		stats++;
 	}
-	reply->header.length = htons(len);
 	return len;
 }
 


### PR DESCRIPTION
From openflow 1.3.5 spec,
> The array has one structure for each table supported by the switch.