### PR TITLE
Need to remove OFPVID_PRESENT bit for printing VLAN_VID.

### DIFF
--- a/ZodiacFX/src/command.c
+++ b/ZodiacFX/src/command.c
@@ -1076,7 +1076,7 @@ void command_openflow(char *command, char *param1, char *param2, char *param3)
 
 							case OFPXMT_OFB_VLAN_VID:
 							memcpy(&oxm_value16, ofp13_oxm_match[i] + sizeof(struct oxm_header13) + match_size, 2);
-							if (oxm_value16 != 0) printf("  VLAN ID: %d\r\n",(ntohs(oxm_value16) - 0x1000));
+							if (oxm_value16 != 0) printf("  VLAN ID: %d\r\n",(ntohs(oxm_value16) - OFPVID_PRESENT));
 							break;
 
 						};
@@ -1140,7 +1140,7 @@ void command_openflow(char *command, char *param1, char *param2, char *param3)
 									{
 										case OFPXMT_OFB_VLAN_VID:
 										memcpy(&oxm_value16, act_set_field->field + sizeof(struct oxm_header13), 2);
-										printf("   Set VLAN ID: %d\r\n",(ntohs(oxm_value16) - 0x1000));
+										printf("   Set VLAN ID: %d\r\n",(ntohs(oxm_value16) - OFPVID_PRESENT));
 										break;
 
 										case OFPXMT_OFB_ETH_SRC:

--- a/ZodiacFX/src/openflow/openflow_13.c
+++ b/ZodiacFX/src/openflow/openflow_13.c
@@ -255,7 +255,7 @@ void nnOF13_tablelookup(uint8_t *p_uc_data, uint32_t *ul_size, int port)
 							p_uc_data[14] = (p_uc_data[14] & 0xf0) | (oxm_value[0] & 0x0f);
 							p_uc_data[15] = oxm_value[1];
 							memcpy(&fields.vlanid, oxm_value, 2);
-							TRACE("Set VID %u", ntohs(fields.vlanid));
+							TRACE("Set VID %u", (ntohs(fields.vlanid) - OFPVID_PRESENT));
 						}
 						break;
 						// Set Source Ethernet Address


### PR DESCRIPTION
**Debug trace** at the moment prints the VLAN VID including the top (OFPVID_PRESENT) bit set which means.

Remove the bit before we print so that we get the correct VLAN ID printed on screen.