### PR TITLE
Fix OFPP_TABLE for OpenFlow 1.0 and introduce it for 1.3

### DIFF
--- a/ZodiacFX/src/openflow/openflow_10.c
+++ b/ZodiacFX/src/openflow/openflow_10.c
@@ -59,7 +59,7 @@ extern struct zodiac_config Zodiac_Config;
 extern struct ofp_switch_config Switch_config;
 
 //Internal Functions
-void packet_in(uint8_t *buffer, uint16_t ul_size, uint8_t port, uint8_t reason);
+void packet_in(uint8_t *buffer, uint16_t ul_size, uint32_t port, uint8_t reason);
 void features_reply10(uint32_t xid);
 void set_config10(struct ofp_header * msg);
 void config_reply(uint32_t xid);
@@ -757,7 +757,7 @@ void packet_out(struct ofp_header *msg)
 *	@param reason - reason for the packet in.
 *
 */
-void packet_in(uint8_t *buffer, uint16_t ul_size, uint8_t port, uint8_t reason)
+void packet_in(uint8_t *buffer, uint16_t ul_size, uint32_t port, uint8_t reason)
 {
 	uint16_t send_size = ul_size;
 	if(tcp_sndbuf(tcp_pcb) < (send_size + 18)) return;

--- a/ZodiacFX/src/openflow/openflow_13.c
+++ b/ZodiacFX/src/openflow/openflow_13.c
@@ -89,7 +89,7 @@ int multi_flow_reply13(uint8_t *buffer, struct ofp13_multipart_request *msg);
 int multi_meter_stats_reply13(uint8_t *buffer, struct ofp13_multipart_request * req);
 int multi_meter_config_reply13(uint8_t *buffer, struct ofp13_multipart_request * req);
 int multi_meter_features_reply13(uint8_t *buffer, struct ofp13_multipart_request * req);
-void packet_in13(uint8_t *buffer, uint16_t ul_size, uint8_t port, uint8_t reason, int flow);
+void packet_in13(uint8_t *buffer, uint16_t ul_size, uint32_t port, uint8_t reason, int flow);
 void packet_out13(struct ofp_header *msg);
 void meter_mod13(struct ofp_header *msg);
 void meter_add13(struct ofp_header *msg);
@@ -1889,7 +1889,7 @@ void flow_delete_strict13(struct ofp_header *msg)
 *	@param reason - reason for the packet in.
 *
 */
-void packet_in13(uint8_t *buffer, uint16_t ul_size, uint8_t port, uint8_t reason, int flow)
+void packet_in13(uint8_t *buffer, uint16_t ul_size, uint32_t port, uint8_t reason, int flow)
 {
 	TRACE("openflow_13.c: Packet in from packet received on port %d reason = %d (%d bytes)", port, reason, ul_size);
 	uint16_t size = 0;
@@ -1944,6 +1944,14 @@ void packet_out13(struct ofp_header *msg)
 	if (ntohs(act_hdr->type) != OFPAT13_OUTPUT) return;
 	struct ofp13_action_output *act_out = act_hdr;
 	uint32_t outPort = htonl(act_out->port);
+
+	if (outPort == OFPP13_TABLE)
+	{
+		TRACE("openflow_13.c: Packet out TABLE (port %d)", inPort);
+		nnOF13_tablelookup(ptr, &size, inPort);
+		return;
+	}
+
 	if (outPort == OFPP13_FLOOD)
 	{
 		outPort = 7 - (1 << (inPort-1));	// Need to fix this, may also send out the Non-OpenFlow port


### PR DESCRIPTION
The packet_in functions' signatures do not allow for the
reserved 32 bit long port numbers to be an incoming port.
The OFPP13_TABLE is present in a header file, but was
never used. Add support in OF 1.3 similarly to 1.0.