### PR TITLE
Incorrect header length in flow removal messages

### DIFF
--- a/ZodiacFX/src/openflow/openflow_13.c
+++ b/ZodiacFX/src/openflow/openflow_13.c
@@ -2486,7 +2486,7 @@ void flowrem_notif13(int flowid, uint8_t reason)
 
 	ofr.header.type = OFPT13_FLOW_REMOVED;
 	ofr.header.version = OF_Version;
-	ofr.header.length = htons((sizeof(struct ofp13_flow_removed) + ntohs(flow_match13[flowid]->match.length)-4));
+	ofr.header.length = htons((sizeof(struct ofp13_flow_removed) + ntohs(flow_match13[flowid]->match.length)-4) + (ntohs(flow_match13[flowid]->match.length) % 8));
 	ofr.header.xid = 0;
 	ofr.cookie = flow_match13[flowid]->cookie;
 	ofr.reason = reason;


### PR DESCRIPTION
flowrem_notif13 calculates incorrect header length in some cases. This leads to missing padding in match structs while generating TCP packets. The malformed packets cause continuous connection resets with controller. 

Refer http://forums.northboundnetworks.com/index.php?topic=919.0

Header length is calculated from incoming match struct which has variable length. For match.length=20, the full match structure is copied & a padding of 4 bytes is generated. For other values like match.length=18, no extra padding is generated as part of the match structure.

The fix modifies the length calculation to accommodate the variable length of the incoming match struct. As a result, correct padding of 6 bytes is now generated for match.length=18.