### PR TITLE
Fix invalid padding in the ofp13_flow_removed message

### DIFF
--- a/ZodiacFX/src/openflow/openflow_13.c
+++ b/ZodiacFX/src/openflow/openflow_13.c
@@ -2530,11 +2530,22 @@ void flowrem_notif13(int flowid, uint8_t reason)
 {
 	struct ofp13_flow_removed ofr;
 	double diff;
-	char flow_rem[128];
+	uint16_t match_length;
+	uint16_t match_padding;
+	char flow_rem[128] = {0};
 
 	ofr.header.type = OFPT13_FLOW_REMOVED;
 	ofr.header.version = OF_Version;
-	ofr.header.length = htons((sizeof(struct ofp13_flow_removed)-4) + ntohs(flow_match13[flowid]->match.length));
+
+	// calculate the padding such that ofp_match is 32-bit aligned
+	match_length = ntohs(flow_match13[flowid]->match.length);
+	match_padding = ((match_length + 7)/8*8 - match_length);
+
+	// match_length includes the total length of the ofp_match field (including header,
+	// excluding padding), but sizeof(struct ofp13_flow_removed) already counted the
+	// 8 bytes of sizeof(struct ofp_match)
+	// => subtract the duplicate 8 bytes + length of match field + padding of match field
+	ofr.header.length = htons((sizeof(struct ofp13_flow_removed) - 8) + match_length + match_padding);
 	ofr.header.xid = 0;
 	ofr.cookie = flow_match13[flowid]->cookie;
 	ofr.reason = reason;
@@ -2553,7 +2564,7 @@ void flowrem_notif13(int flowid, uint8_t reason)
 	{
 		memcpy(flow_rem + (sizeof(struct ofp13_flow_removed)-4), ofp13_oxm_match[flowid], ntohs(flow_match13[flowid]->match.length)-4);
 	}
-	sendtcp(&flow_rem, htons(ofr.header.length)-4);
+	sendtcp(&flow_rem, htons(ofr.header.length));
 	TRACE("openflow_13.c: Flow removed notification sent");
 	return;
 }


### PR DESCRIPTION
The issue mentioned in [1](http://forums.northboundnetworks.com/index.php?topic=928.0) and [2](http://forums.northboundnetworks.com/index.php?topic=919.0) was not fixed in v0.83. The reason is a not correctly calculated padding. Both, fixes in 5b9dc436bac5942ef7f73aad238220d9f084e953 and in #85 only solve the issue in certain cases. In addition, v0.83 causes the generated frame to be too short, such that ONOS discards it. #85 calculates the correct padding only for certain match.length.

Both solutions lead to a crashing ONOS in specific flow matches. This PR should solve the issue and calculate the padding according to the specification. More details in the code comment.

# Example of different ofp13_match.length values
The following table shows example message sizes for different match.length values in the different code versions.

```c
sizeof(struct ofp_flow_removed) == 56
sizeof(struct ofp_match) == 8
```

v0.82:

```c
(sizeof(struct ofp13_flow_removed) + ntohs(flow_match13[flowid]->match.length)-4)
...
sendtcp(&flow_rem, htons(ofr.header.length));
```

v0.83:

```c
(sizeof(struct ofp13_flow_removed)-4) + ntohs(flow_match13[flowid]->match.length)
...
sendtcp(&flow_rem, htons(ofr.header.length)-4);
```

#85: 
```c
(sizeof(struct ofp13_flow_removed) + ntohs(flow_match13[flowid]->match.length)-4) + (ntohs(flow_match13[flowid]->match.length) % 8)
...
sendtcp(&flow_rem, htons(ofr.header.length));
```

PR:

```c
match_length = ntohs(flow_match13[flowid]->match.length);
match_padding = ((match_length + 7)/8*8 - match_length);
(sizeof(struct ofp13_flow_removed) - sizeof(struct ofp_match)) + match_length + match_padding
...
sendtcp(&flow_rem, htons(ofr.header.length));
```

Results (correct values are **bold**):

| match.length | v0.82 | v0.83 | #85 | PR |
| --- | --- | --- | --- | --- |
| 9 | 61 | 61 | 62 | **64** |
| 10 | 62 | 62 | **64** | **64** |
| 11 | 63 | 63 | 66 | **64** |
| 12 | **64** | **64** | 68 | **64** |
| 13 | 65 | 65 | 70 | **64** |
| 14 | 66 | 66 | 72 | **64** |
| 15 | 67 | 67 | 74 | **64** |
| 16 | 68 | 68 | 68 | **64** |
| 17 | 69 | 69 | 70 | **72** |
| 18 | 70 | 70 | **72** | **72** |
| 19 | 71 | 71 | 74 | **72** |
| 20 | **72** | **72** | 76 | **72** |
| 21 | 73 | 73 | 78 | **72** |
| 22 | 74 | 74 | 80 | **72** |
| 23 | 75 | 75 | 82 | **72** |
| 24 | 76 | 76 | 76 | **72** |
| 25 | 77 | 77 | 78 | **80** |
| 26 | 78 | 78 | **80** | **80** |
| 27 | 79 | 79 | 82 | **80** |
| 28 | **80** | **80** | 84 | **80** |
| 29 | 81 | 81 | 86 | **80** |
| ... | ... | ... | ... |